### PR TITLE
Support field handle overrides in restriction service

### DIFF
--- a/src/services/RestrictionService.php
+++ b/src/services/RestrictionService.php
@@ -13,13 +13,6 @@ use craft\elements\User;
 use craft\events\ExecuteGqlQueryEvent;
 use craft\events\ModelEvent;
 use craft\events\RegisterGqlQueriesEvent;
-use craft\gql\arguments\elements\Asset as AssetArguments;
-use craft\gql\arguments\elements\Entry as EntryArguments;
-use craft\gql\arguments\elements\GlobalSet as GlobalSetArguments;
-use craft\gql\interfaces\elements\Asset as AssetInterface;
-use craft\gql\interfaces\elements\Entry as EntryInterface;
-use craft\gql\interfaces\elements\GlobalSet as GlobalSetInterface;
-use craft\helpers\Gql as GqlHelper;
 use craft\helpers\StringHelper;
 use craft\models\GqlSchema;
 use craft\services\Entries;
@@ -28,7 +21,6 @@ use GraphQL\Error\Error;
 use GraphQL\Language\AST\FieldNode;
 use GraphQL\Language\AST\OperationDefinitionNode;
 use GraphQL\Language\Parser;
-use GraphQL\Type\Definition\Type;
 use InvalidArgumentException;
 use jamesedmonston\graphqlauthentication\GraphqlAuthentication;
 use jamesedmonston\graphqlauthentication\resolvers\Asset as AssetResolver;
@@ -38,6 +30,11 @@ use yii\base\Event;
 
 class RestrictionService extends Component
 {
+    /**
+     * @var array<string,array<int,string>>
+     */
+    private array $fieldHandleOverrides = [];
+
     // Public Methods
     // =========================================================================
 
@@ -251,6 +248,8 @@ class RestrictionService extends Component
         $privateFields = array_keys(array_filter($fieldPermissions, function($permission) {
             return $permission === 'private';
         }));
+        $queryFields = $this->expandHandles($queryFields);
+        $privateFields = $this->expandHandles($privateFields);
 
         foreach ($definitions as $definition) {
             /** @phpstan-ignore-next-line */
@@ -466,6 +465,45 @@ class RestrictionService extends Component
         }));
 
         return $authorOnlyVolumes;
+    }
+
+    private function buildFieldHandleOverrides(): void
+    {
+        if (!empty($this->fieldHandleOverrides)) {
+            return;
+        }
+
+        $fieldsService = Craft::$app->getFields();
+        $elementTypes = [Entry::class, Asset::class, GlobalSet::class, User::class];
+
+        foreach ($elementTypes as $type) {
+            foreach ($fieldsService->getLayoutsByType($type) as $layout) {
+                foreach ($layout->getCustomFields() as $layoutField) {
+                    $field = $layoutField->getField();
+                    if (!$field) {
+                        continue;
+                    }
+                    $default = $field->handle;
+                    $handle = $layoutField->attribute ?? $layoutField->handle ?? $default;
+                    if ($handle !== $default) {
+                        $this->fieldHandleOverrides[$default][] = $handle;
+                    }
+                }
+            }
+        }
+    }
+
+    private function expandHandles(array $handles): array
+    {
+        $this->buildFieldHandleOverrides();
+        $expanded = [];
+        foreach ($handles as $handle) {
+            $expanded[] = $handle;
+            foreach ($this->fieldHandleOverrides[$handle] ?? [] as $extra) {
+                $expanded[] = $extra;
+            }
+        }
+        return array_values(array_unique($expanded));
     }
 
     // Protected Methods


### PR DESCRIPTION
## Summary
- check field handle overrides within GraphQL restrictions

## Testing
- `composer check-cs`
- `composer phpstan` *(fails: Found 20 errors)*

------
https://chatgpt.com/codex/tasks/task_b_6880c0d26b1083218879d8569250fffb