### PR TITLE
Handle layout field overwrites

### DIFF
--- a/src/services/RestrictionService.php
+++ b/src/services/RestrictionService.php
@@ -21,6 +21,7 @@ use craft\gql\interfaces\elements\Entry as EntryInterface;
 use craft\gql\interfaces\elements\GlobalSet as GlobalSetInterface;
 use craft\helpers\Gql as GqlHelper;
 use craft\helpers\StringHelper;
+use craft\fieldlayoutelements\CustomField as FieldLayoutCustomField;
 use craft\models\GqlSchema;
 use craft\services\Entries;
 use craft\services\Gql;
@@ -38,6 +39,12 @@ use yii\base\Event;
 
 class RestrictionService extends Component
 {
+    /**
+     * Map of field handles to any handle overwrites defined in field layouts.
+     *
+     * @var array|null
+     */
+    private ?array $fieldHandleOverwrites = null;
     // Public Methods
     // =========================================================================
 
@@ -251,6 +258,9 @@ class RestrictionService extends Component
         $privateFields = array_keys(array_filter($fieldPermissions, function($permission) {
             return $permission === 'private';
         }));
+
+        $queryFields = $this->applyHandleOverwrites($queryFields);
+        $privateFields = $this->applyHandleOverwrites($privateFields);
 
         foreach ($definitions as $definition) {
             /** @phpstan-ignore-next-line */
@@ -596,5 +606,60 @@ class RestrictionService extends Component
         }
 
         return true;
+    }
+
+    /**
+     * Returns an array mapping field handles to any handle overwrites defined
+     * within field layouts.
+     *
+     * @return array<string, string[]>
+     */
+    private function getFieldHandleOverwrites(): array
+    {
+        if ($this->fieldHandleOverwrites !== null) {
+            return $this->fieldHandleOverwrites;
+        }
+
+        $overwrites = [];
+        $fieldsService = Craft::$app->getFields();
+
+        foreach ($fieldsService->getAllLayouts() as $layout) {
+            foreach ($layout->getTabs() as $tab) {
+                foreach ($tab->getElements() as $element) {
+                    if ($element instanceof FieldLayoutCustomField) {
+                        $field = $element->getField();
+                        $override = $element->handle;
+                        if ($override && $override !== $field->handle) {
+                            $overwrites[$field->handle][] = $override;
+                        }
+                    }
+                }
+            }
+        }
+
+        $this->fieldHandleOverwrites = $overwrites;
+
+        return $this->fieldHandleOverwrites;
+    }
+
+    /**
+     * Expands a list of field handles to include any handle overwrites.
+     *
+     * @param string[] $handles
+     * @return string[]
+     */
+    private function applyHandleOverwrites(array $handles): array
+    {
+        $overwrites = $this->getFieldHandleOverwrites();
+
+        foreach ($handles as $handle) {
+            if (!empty($overwrites[$handle])) {
+                foreach ($overwrites[$handle] as $alias) {
+                    $handles[] = $alias;
+                }
+            }
+        }
+
+        return array_values(array_unique($handles));
     }
 }


### PR DESCRIPTION
## Summary
- support custom field handles in field layouts
- include any field handle overwrites when validating GraphQL field access

## Testing
- `php -l src/services/RestrictionService.php`

------
https://chatgpt.com/codex/tasks/task_b_6880c0d26b1083218879d8569250fffb