### PR TITLE
fix: attach resolvers to „resolve“ method instead of not existing „re…

### DIFF
--- a/src/services/RestrictionService.php
+++ b/src/services/RestrictionService.php
@@ -120,7 +120,7 @@ class RestrictionService extends Component
 
         foreach ($resolvers as $name => $resolver) {
             if (isset($event->queries[$name])) {
-                $event->queries[$name]['resolver'] = $resolver;
+                $event->queries[$name]['resolve'] = $resolver;
             }
         }
     }


### PR DESCRIPTION
…solver“ method

based on docs https://docs.craftcms.com/api/v5/craft-gql-base-resolver.html#method-resolve